### PR TITLE
Feature: Option to truncate overhead dialogue

### DIFF
--- a/src/main/java/com/npcdialogue/DialogueConfig.java
+++ b/src/main/java/com/npcdialogue/DialogueConfig.java
@@ -118,4 +118,15 @@ public interface DialogueConfig extends Config {
     default boolean displayOverheadPlayerDialogue() {
         return true;
     }
+
+    @ConfigItem(
+        keyName = "truncateOverheadText",
+        name = "Truncate Overhead",
+        description = "Truncate overhead text after X characters<br>Set to 0 to disable",
+        section = SECTION_OVERHEAD,
+        position = 303
+    )
+    default int truncateOverheadText() {
+        return 0;
+    }
 }

--- a/src/main/java/com/npcdialogue/service/OverheadService.java
+++ b/src/main/java/com/npcdialogue/service/OverheadService.java
@@ -1,5 +1,6 @@
 package com.npcdialogue.service;
 
+import com.npcdialogue.DialogueConfig;
 import com.npcdialogue.model.Dialogue;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
@@ -10,18 +11,31 @@ import javax.inject.Inject;
 @Slf4j
 public class OverheadService {
     @Inject private Client client;
+    @Inject private DialogueConfig config;
 
     public void setOverheadTextNpc(Actor npc, Dialogue dialogue) {
-        npc.setOverheadText(dialogue.getText());
+        npc.setOverheadText(truncate(dialogue.getText()));
         log.debug("Set overhead dialogue for {} to: {}", npc.getName(), dialogue.getText());
     }
 
     public void setOverheadTextPlayer(Dialogue dialogue) {
-        client.getLocalPlayer().setOverheadText(dialogue.getText());
+        client.getLocalPlayer().setOverheadText(truncate(dialogue.getText()));
         log.debug("Set overhead dialogue for player to: {}", dialogue.getText());
     }
 
     public void clearOverheadText(Actor actor) {
         actor.setOverheadText(null);
+    }
+
+    private String truncate(String text) {
+        int maxLength = config.truncateOverheadText();
+
+        if (maxLength <= 0 || text == null || text.length() <= maxLength) {
+            return text;
+        } else if (maxLength <= 3) {
+            return text.substring(0, maxLength);
+        }
+
+        return text.substring(0, maxLength - 3) + "...";
     }
 }


### PR DESCRIPTION
Add configurable truncation for overhead text

This adds an option to limit overhead text length by character count. If the configured limit is exceeded, the text is truncated and appended with "...".

If the limit is set to 0, truncation is disabled.