### PR TITLE
Feature: Option for overhead message duration

### DIFF
--- a/src/main/java/com/npcdialogue/DialogueConfig.java
+++ b/src/main/java/com/npcdialogue/DialogueConfig.java
@@ -120,11 +120,22 @@ public interface DialogueConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "durationOverheadText",
+        name = "Overhead Duration",
+        description = "How long overhead text lasts. 30 cycles = 1 game tick (~0.6s).<br>Default: 100 (~3.3 ticks)",
+        section = SECTION_OVERHEAD,
+        position = 303
+    )
+    default int durationOverheadText() {
+        return 100;
+    }
+
+    @ConfigItem(
         keyName = "truncateOverheadText",
         name = "Truncate Overhead",
         description = "Truncate overhead text after X characters<br>Set to 0 to disable",
         section = SECTION_OVERHEAD,
-        position = 303
+        position = 304
     )
     default int truncateOverheadText() {
         return 0;

--- a/src/main/java/com/npcdialogue/DialoguePlugin.java
+++ b/src/main/java/com/npcdialogue/DialoguePlugin.java
@@ -7,7 +7,6 @@ import com.npcdialogue.service.OverheadService;
 import com.npcdialogue.util.DialogueUtils;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
-import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.events.*;
@@ -20,9 +19,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.Text;
 
 import javax.inject.Inject;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 
 import static net.runelite.api.gameval.VarbitID.CUTSCENE_STATUS;
 
@@ -34,7 +30,6 @@ import static net.runelite.api.gameval.VarbitID.CUTSCENE_STATUS;
 )
 public class DialoguePlugin extends Plugin {
     private static final int SCRIPT_CHAT_DIALOGUE = 600;
-    private static final int TIMEOUT_TICKS = 3;
 
     @Inject private Client client;
     @Inject private DialogueConfig config;
@@ -42,8 +37,6 @@ public class DialoguePlugin extends Plugin {
     @Inject private OverheadService overheadService;
 
     private NPC lastInteractedActor = null;
-    // Collection of actors and their overhead text timestamp
-    private final Map<Actor, Integer> lastActorOverheadTickTime = new HashMap<>();
 
     @Provides
     DialogueConfig provideConfig(ConfigManager configManager) {
@@ -68,7 +61,6 @@ public class DialoguePlugin extends Plugin {
             }
             if (config.displayOverheadPlayerDialogue()) {
                 overheadService.setOverheadTextPlayer(dialogue);
-                lastActorOverheadTickTime.put(client.getLocalPlayer(), client.getTickCount());
             }
         }
 
@@ -83,7 +75,6 @@ public class DialoguePlugin extends Plugin {
                     return;
                 }
                 overheadService.setOverheadTextNpc(actor, dialogue);
-                lastActorOverheadTickTime.put(actor, client.getTickCount());
             }
         }
     }
@@ -108,20 +99,6 @@ public class DialoguePlugin extends Plugin {
             return lastInteractedActor;
         }
         return null;
-    }
-
-    /**
-     * Checks overhead text duration and clears overhead text if expired
-     */
-    @Subscribe
-    public void onGameTick(GameTick event) {
-        for (Iterator<Actor> iterator = lastActorOverheadTickTime.keySet().iterator(); iterator.hasNext(); ) {
-            Actor actor = iterator.next();
-            if (client.getTickCount() - lastActorOverheadTickTime.get(actor) > TIMEOUT_TICKS) {
-                overheadService.clearOverheadText(actor);
-                iterator.remove();
-            }
-        }
     }
 
     @Subscribe
@@ -152,22 +129,6 @@ public class DialoguePlugin extends Plugin {
     }
 
     /**
-     * Looks for player chat messages so overhead is not prematurely cleared
-     */
-    @Subscribe
-    public void onChatMessage(ChatMessage event) {
-        // Check if player sends public chat message while player overhead is being shown
-        if (client.getLocalPlayer() != null && event.getType() == ChatMessageType.PUBLICCHAT && event.getName().equals(client.getLocalPlayer().getName())) {
-            if (client.getLocalPlayer().getOverheadText() != null) {
-                // Remove timer to not prematurely clear public chat overhead
-                if (lastActorOverheadTickTime.remove(client.getLocalPlayer()) != null) {
-                    log.debug("Player sent chat while overhead was being displayed. Cleared overhead counter for player actor");
-                }
-            }
-        }
-    }
-
-    /**
      * Save NPCs the player interacts with to lastInteractedActor variable
      */
     @Subscribe
@@ -180,25 +141,13 @@ public class DialoguePlugin extends Plugin {
         log.debug("Interacted with actor: {} ({})", lastInteractedActor.getName(), lastInteractedActor.getId());
     }
 
-    /**
-     * Reset and clear overhead text and actor history when logging in/out
-     */
     @Subscribe
     public void onGameStateChanged(GameStateChanged gameStateChanged) {
         switch (gameStateChanged.getGameState()) {
-            case LOGGED_IN:
-                // When logging in clear all known overhead text
-                for (Actor actor : lastActorOverheadTickTime.keySet()) {
-                    overheadService.clearOverheadText(actor);
-                }
-                lastActorOverheadTickTime.clear();
-                break;
             case CONNECTION_LOST:
             case HOPPING:
             case LOGIN_SCREEN:
-                // Clear actor history when logging out, hopping or losing connection
                 lastInteractedActor = null;
-                lastActorOverheadTickTime.clear();
                 break;
             default:
                 break;

--- a/src/main/java/com/npcdialogue/service/OverheadService.java
+++ b/src/main/java/com/npcdialogue/service/OverheadService.java
@@ -10,21 +10,24 @@ import javax.inject.Inject;
 
 @Slf4j
 public class OverheadService {
+    // See: https://osrs-docs.com/docs/packets/outgoing/updating/masks/say
+    private static final int OVERHEAD_TIMEOUT_CYCLES_PUBLIC = 150;
+    private static final int OVERHEAD_TIMEOUT_CYCLES_NPC = 100;
+
     @Inject private Client client;
     @Inject private DialogueConfig config;
 
     public void setOverheadTextNpc(Actor npc, Dialogue dialogue) {
         npc.setOverheadText(truncate(dialogue.getText()));
+        npc.setOverheadCycle(OVERHEAD_TIMEOUT_CYCLES_NPC);
         log.debug("Set overhead dialogue for {} to: {}", npc.getName(), dialogue.getText());
     }
 
     public void setOverheadTextPlayer(Dialogue dialogue) {
-        client.getLocalPlayer().setOverheadText(truncate(dialogue.getText()));
+        Actor player = client.getLocalPlayer();
+        player.setOverheadText(truncate(dialogue.getText()));
+        player.setOverheadCycle(OVERHEAD_TIMEOUT_CYCLES_NPC);
         log.debug("Set overhead dialogue for player to: {}", dialogue.getText());
-    }
-
-    public void clearOverheadText(Actor actor) {
-        actor.setOverheadText(null);
     }
 
     private String truncate(String text) {

--- a/src/main/java/com/npcdialogue/service/OverheadService.java
+++ b/src/main/java/com/npcdialogue/service/OverheadService.java
@@ -10,23 +10,19 @@ import javax.inject.Inject;
 
 @Slf4j
 public class OverheadService {
-    // See: https://osrs-docs.com/docs/packets/outgoing/updating/masks/say
-    private static final int OVERHEAD_TIMEOUT_CYCLES_PUBLIC = 150;
-    private static final int OVERHEAD_TIMEOUT_CYCLES_NPC = 100;
-
     @Inject private Client client;
     @Inject private DialogueConfig config;
 
     public void setOverheadTextNpc(Actor npc, Dialogue dialogue) {
         npc.setOverheadText(truncate(dialogue.getText()));
-        npc.setOverheadCycle(OVERHEAD_TIMEOUT_CYCLES_NPC);
+        npc.setOverheadCycle(config.durationOverheadText());
         log.debug("Set overhead dialogue for {} to: {}", npc.getName(), dialogue.getText());
     }
 
     public void setOverheadTextPlayer(Dialogue dialogue) {
         Actor player = client.getLocalPlayer();
         player.setOverheadText(truncate(dialogue.getText()));
-        player.setOverheadCycle(OVERHEAD_TIMEOUT_CYCLES_NPC);
+        player.setOverheadCycle(config.durationOverheadText());
         log.debug("Set overhead dialogue for player to: {}", dialogue.getText());
     }
 


### PR DESCRIPTION
Add an option for changing the duration of the overhead text using Actor#setOverheadCycle. Default value is set based on the say mask for NPCs and values used by server-invoked overhead chat. 

See: [osrs-docs.com (Say Mask)](https://osrs-docs.com/docs/packets/outgoing/updating/masks/say/)